### PR TITLE
(feat): host env var for metric client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,10 @@ The ``NEW_RELIC_SERVICE_NAME`` environment variable can be set to customize the
 ``service.name`` attribute on all generated metrics. The default value is
 ``Airflow``.
 
+``NEW_RELIC_HOST`` environment variable can be used to set datacenter host.
+For example, to send metrics to EU data center set this variable to ``metric-api.eu.newrelic.com``
+By default metrics will be send to US data center.
+
 
 Airflow Versions >= 1.10
 ++++++++++++++++++++++++

--- a/src/newrelic_airflow_plugin/newrelic_plugin.py
+++ b/src/newrelic_airflow_plugin/newrelic_plugin.py
@@ -59,7 +59,8 @@ class NewRelicStatsLogger(object):
                 return harvester
 
             insert_key = os.environ["NEW_RELIC_INSERT_KEY"]
-            client = MetricClient(insert_key)
+            service_name = os.environ.get("NEW_RELIC_HOST", "metric-api.newrelic.com")
+            client = MetricClient(insert_key, host)
 
             service_name = os.environ.get("NEW_RELIC_SERVICE_NAME", "Airflow")
             batch = MetricBatch({"service.name": service_name})

--- a/src/newrelic_airflow_plugin/newrelic_plugin.py
+++ b/src/newrelic_airflow_plugin/newrelic_plugin.py
@@ -59,7 +59,7 @@ class NewRelicStatsLogger(object):
                 return harvester
 
             insert_key = os.environ["NEW_RELIC_INSERT_KEY"]
-            service_name = os.environ.get("NEW_RELIC_HOST", "metric-api.newrelic.com")
+            host = os.environ.get("NEW_RELIC_HOST", "metric-api.newrelic.com")
             client = MetricClient(insert_key, host)
 
             service_name = os.environ.get("NEW_RELIC_SERVICE_NAME", "Airflow")

--- a/src/newrelic_airflow_plugin/newrelic_plugin.py
+++ b/src/newrelic_airflow_plugin/newrelic_plugin.py
@@ -59,8 +59,8 @@ class NewRelicStatsLogger(object):
                 return harvester
 
             insert_key = os.environ["NEW_RELIC_INSERT_KEY"]
-            host = os.environ.get("NEW_RELIC_HOST", "metric-api.newrelic.com")
-            client = MetricClient(insert_key, host)
+            host = os.environ.get("NEW_RELIC_HOST", None)
+            client = MetricClient(insert_key, host=host)
 
             service_name = os.environ.get("NEW_RELIC_SERVICE_NAME", "Airflow")
             batch = MetricBatch({"service.name": service_name})


### PR DESCRIPTION
Add `NEW_RELIC_HOST` env variable so that EU datacenter url can be passed