### PR TITLE
Fix import of DummyStatsLogger for airflow >= v2.6.0

### DIFF
--- a/src/newrelic_airflow_plugin/newrelic_plugin.py
+++ b/src/newrelic_airflow_plugin/newrelic_plugin.py
@@ -110,7 +110,7 @@ class NewRelicStatsPlugin(AirflowPlugin):
 
     @classmethod
     def get_stats_logger(cls):
-        """Import StatsLogger and Stats classes."""
+        """Handle importing of StatsLogger and Stats classes."""
         StatsLogger = Stats = None
 
         stats_logger_modules = ["airflow.stats", "airflow.settings"]


### PR DESCRIPTION
Fix the `DummyStatsLogger` import.

Closes: #40 

This bug appeared because [DummyStatsLogger was renamed to NullStatsLogger](https://github.com/apache/airflow/pull/30001) in airflow 2.6.0.

The import of the `DummyStatsLogger` is try-excepted, so the `DummyStatsLogger` class is None. It leads to the `AttributeError: 'NoneType' object has no attribute 'incr'`.