### PR TITLE
Make the plugin compatible with Airflow >= "v2.6.0"

### DIFF
--- a/src/newrelic_airflow_plugin/newrelic_plugin.py
+++ b/src/newrelic_airflow_plugin/newrelic_plugin.py
@@ -73,23 +73,23 @@ class NewRelicStatsLogger(object):
             return harvester
 
     @classmethod
-    def incr(cls, stat, count=1, rate=1):
+    def incr(cls, stat, count=1, rate=1, **kwargs):
         harvester = cls.harvester()
         harvester.batch.record_count(stat, count)
         harvester.send_for_metric(stat)
 
     @classmethod
-    def decr(cls, stat, count=1, rate=1):
+    def decr(cls, stat, count=1, rate=1, **kwargs):
         raise NotImplementedError
 
     @classmethod
-    def gauge(cls, stat, value, rate=1, delta=False):
+    def gauge(cls, stat, value, rate=1, delta=False, **kwargs):
         harvester = cls.harvester()
         harvester.batch.record_gauge(stat, value)
         harvester.send_for_metric(stat)
 
     @classmethod
-    def timing(cls, stat, dt):
+    def timing(cls, stat, dt, **kwargs):
         value = None
         tags = None
         try:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -76,21 +76,21 @@ def test_on_dagrun_failure(stats, capture_sent):
 
 
 def test_incr(stats):
-    stats.incr("test_metric")
+    stats.incr("test_metric", tags={})
 
 
 def test_decr(stats):
-    stats.decr("test_metric")
+    stats.decr("test_metric", tags={})
 
 
 def test_gauge(stats):
-    stats.gauge("test_metric", 100)
+    stats.gauge("test_metric", 100, tags={})
 
 
 def test_timing_datetime(stats):
     dt = datetime.timedelta(microseconds=1000)
-    stats.timing("test_timer", dt)
+    stats.timing("test_timer", dt, tags={})
 
 
 def test_timing_float(stats):
-    stats.timing("test_timer", 0.7)
+    stats.timing("test_timer", 0.7, tags={})


### PR DESCRIPTION
Closes: #40 

1. Fix the `DummyStatsLogger` import. 
This bug appeared because [DummyStatsLogger was renamed to NoStatsLogger](https://github.com/apache/airflow/pull/30001) in Airflow v2.6.0.
The import of the `DummyStatsLogger` is try-excepted, so the `DummyStatsLogger` class is None. It leads to the `AttributeError: 'NoneType' object has no attribute 'incr'`.

2. Fix the `unexpected keyword argument` error after [the "tag" argument was added](https://github.com/apache/airflow/pull/29093) to StatsLogger in Airflow v2.6.0
